### PR TITLE
Fix image name processing

### DIFF
--- a/app/watchers/providers/docker/Docker.js
+++ b/app/watchers/providers/docker/Docker.js
@@ -339,7 +339,7 @@ class Docker extends Component {
         const creationDate = containerImage.data.Created;
 
         // Parse image to get registry, organization...
-        const parsedImage = parse(container.data.Image);
+        const parsedImage = parse((containerImage.data.RepoTags || [])[0] || container.data.Image);
         const version = parsedImage.tag || 'latest';
         const parsedVersion = semver.coerce(version);
         const isSemver = parsedVersion !== null && parsedVersion !== undefined;


### PR DESCRIPTION
Storing image name in container object data is rather odd in Docker and shouldn't be considered reliable. Consider situation from the documentation, and run the container using tag:

```
docker run -d --name wud -v "/var/run/docker.sock:/var/run/docker.sock" -p 3000:3000 fmartinou/whats-up-docker
```

When you visit the page, the image is displayed properly as `fmartinou/whats-up-docker` with `latest` version. But what would happen if you run the same image, using it's ID instead of the name?

```
docker run -d --name wud -v "/var/run/docker.sock:/var/run/docker.sock" -p 3000:3000 sha256:2709895d99806a15a9050cae18208df4a54822e69752a977a271dd9cc22dea31
```

Now you may see, that image name is displayed improperly (`sha256` was parsed as image name, and the hash as version).
Unfortunately some automated tools used to orchestrate containers rely solely on those IDs (instead of names) and this pose a problem. This patch is an attempt to address that, and changes the default behavior to use image tags instead of container image alias. Only if those tags can't be found (which shouldn't happen), container image name is used.