### PR TITLE
Fix missing semver transforms

### DIFF
--- a/app/model/container.js
+++ b/app/model/container.js
@@ -194,8 +194,8 @@ function addUpdateKindProperty(container) {
                         const isSemver = container.image.tag.semver;
                         if (isSemver) {
                             const semverDiff = diffSemver(
-                                container.image.tag.value,
-                                container.result.tag,
+                                transformTag(container.transformTags, container.image.tag.value),
+                                transformTag(container.transformTags, container.result.tag),
                             );
                             switch (semverDiff) {
                             case 'major':

--- a/app/model/container.js
+++ b/app/model/container.js
@@ -138,7 +138,7 @@ function addLinkProperty(container) {
             get() {
                 return getLink(
                     container.linkTemplate,
-                    container.image.tag.value,
+                    transformTag(container.transformTags, container.image.tag.value),
                     container.image.tag.semver,
                 );
             },
@@ -150,7 +150,7 @@ function addLinkProperty(container) {
                 get() {
                     return getLink(
                         container.linkTemplate,
-                        container.result.tag,
+                        transformTag(container.transformTags, container.result.tag),
                         container.image.tag.semver,
                     );
                 },

--- a/app/model/container.test.js
+++ b/app/model/container.test.js
@@ -370,6 +370,30 @@ test('addUpdateKindProperty should detect patch update', () => {
     });
 });
 
+test('addUpdateKindProperty should support transforms', () => {
+    const addUpdateKindProperty = container.__get__('addUpdateKindProperty');
+    const containerObject = {
+        transformTags: '^(\\d+\\.\\d+)-.*-(\\d+) => $1.$2',
+        updateAvailable: true,
+        image: {
+            tag: {
+                value: '1.2-foo-3',
+                semver: true,
+            },
+        },
+        result: {
+            tag: '1.2-bar-4',
+        },
+    };
+    addUpdateKindProperty(containerObject);
+    expect(containerObject.updateKind).toEqual({
+        kind: 'tag',
+        localValue: '1.2-foo-3',
+        remoteValue: '1.2-bar-4',
+        semverDiff: 'patch',
+    });
+});
+
 test('addUpdateKindProperty should detect prerelease semver update', () => {
     const addUpdateKindProperty = container.__get__('addUpdateKindProperty');
     const containerObject = {

--- a/app/model/container.test.js
+++ b/app/model/container.test.js
@@ -218,6 +218,43 @@ test('model should flag updateAvailable when created is different', () => {
     expect(containerValidated.resultChanged(containerDifferent)).toBeTruthy();
 });
 
+test('model should support transforms for links', () => {
+    const containerValidated = container.validate({
+        id: 'container-123456789',
+        name: 'test',
+        watcher: 'test',
+        transformTags: '^(\\d+\\.\\d+)-.*-(\\d+) => $1.$2',
+        // eslint-disable-next-line no-template-curly-in-string
+        linkTemplate: 'https://release-${major}.${minor}.${patch}.acme.com',
+        image: {
+            id: 'image-123456789',
+            registry: {
+                name: 'hub',
+                url: 'https://hub',
+            },
+            name: 'organization/image',
+            tag: {
+                value: '1.2-foo-3',
+                semver: true,
+            },
+            digest: {
+            },
+            architecture: 'arch',
+            os: 'os',
+        },
+        result: {
+            tag: '1.2-bar-4',
+        },
+    });
+
+    expect(containerValidated).toMatchObject({
+        link: 'https://release-1.2.3.acme.com',
+        result: {
+            link: 'https://release-1.2.4.acme.com',
+        },
+    });
+});
+
 test('flatten should be flatten the nested properties with underscores when called', () => {
     const containerValidated = container.validate({
         id: 'container-123456789',

--- a/app/watchers/providers/docker/Docker.js
+++ b/app/watchers/providers/docker/Docker.js
@@ -581,7 +581,7 @@ class Docker extends Component {
         }
         const parsedImage = parse(imageNameToParse);
         const tagName = parsedImage.tag || 'latest';
-        const parsedTag = parseSemver(tagName);
+        const parsedTag = parseSemver(transformTag(transformTags, tagName));
         const isSemver = parsedTag !== null && parsedTag !== undefined;
         const watchDigest = isDigestToWatch(
             container.Labels[wudWatchDigest],

--- a/app/watchers/providers/docker/Docker.test.js
+++ b/app/watchers/providers/docker/Docker.test.js
@@ -413,6 +413,43 @@ test('addImageDetailsToContainer should add an image definition to the container
     });
 });
 
+test('addImageDetailsToContainer should support transforms', async () => {
+    docker.dockerApi = {
+        getImage: () => ({
+            inspect: () => ({
+                Id: 'image-123456789',
+                Architecture: 'arch',
+                Os: 'os',
+            }),
+        }),
+    };
+    const container = {
+        Id: 'container-123456789',
+        Image: 'organization/image:version',
+        Names: ['/test'],
+        Labels: {},
+    };
+    const tagTransform = '^(version)$ => $1-1.0.0';
+
+    const containerWithImage = await docker.addImageDetailsToContainer(
+        container,
+        undefined, // tagInclude
+        undefined, // tagExclude
+        tagTransform,
+    );
+    expect(containerWithImage).toMatchObject({
+        image: {
+            tag: {
+                value: 'version',
+                semver: true,
+            },
+        },
+        result: {
+            tag: 'version',
+        },
+    });
+});
+
 test('watchContainer should return container report when found', async () => {
     storeContainer.getContainer = () => (undefined);
     storeContainer.insertContainer = (container) => (container);


### PR DESCRIPTION
This PR adds missing `transformTag` calls to fix the following semver tag errors when using the `wud.tag.transform` label:

* `tag.semver` in the container result being `false` when the transformed tag should be recognised as semver. This seems to result in updates not working at all as it falls back to digest mode on a fixed tag.
* `updateKind.semverDiff` in the container result being `unknown` instead of `major`/`minor`/`patch`/etc.
* Processing failing with `Cannot destructure property 'major' of 'versionSemver' as it is null.` when `wud.link.template` is configured.