### PR TITLE
feat: save update-available in url on value change

### DIFF
--- a/ui/src/views/ContainersView.vue
+++ b/ui/src/views/ContainersView.vue
@@ -97,6 +97,15 @@ export default {
     },
     onUpdateAvailableChanged() {
       this.updateAvailableSelected = !this.updateAvailableSelected;
+      this.$router.push(
+        this.updateAvailableSelected
+          ? {
+              query: {
+                "update-available": this.updateAvailableSelected,
+              },
+            }
+          : { query: {} },
+      );
     },
     onRefreshAllContainers(containersRefreshed) {
       this.containers = containersRefreshed;


### PR DESCRIPTION
This PR allows to save the `update-available` parameters in URL when clicking the `Update available` switch

![image](https://github.com/fmartinou/whats-up-docker/assets/6990995/c387d74f-1049-4415-a21f-b6f065acabd3)


![image](https://github.com/fmartinou/whats-up-docker/assets/6990995/9e5ebb29-ac60-4465-9a83-54a8c785339f)
