### PR TITLE
add watchatstart conditional including documentation

### DIFF
--- a/app/watchers/providers/docker/Docker.js
+++ b/app/watchers/providers/docker/Docker.js
@@ -217,6 +217,7 @@ class Docker extends Component {
             watchall: this.joi.boolean().default(false),
             watchdigest: this.joi.any(),
             watchevents: this.joi.boolean().default(true),
+            watchatstart: this.joi.boolean().default(true),
         });
     }
 
@@ -231,11 +232,13 @@ class Docker extends Component {
         this.log.info(`Cron scheduled (${this.configuration.cron})`);
         this.watchCron = cron.schedule(this.configuration.cron, () => this.watchFromCron());
 
-        // watch at startup (after all components have been registered)
-        this.watchCronTimeout = setTimeout(
-            () => this.watchFromCron(),
-            START_WATCHER_DELAY_MS,
-        );
+        // watch at startup if enabled (after all components have been registered)
+        if (this.configuration.watchatstart) {
+            this.watchCronTimeout = setTimeout(
+                () => this.watchFromCron(),
+                START_WATCHER_DELAY_MS,
+            );
+        }
 
         // listen to docker events
         if (this.configuration.watchevents) {

--- a/app/watchers/providers/docker/Docker.test.js
+++ b/app/watchers/providers/docker/Docker.test.js
@@ -29,6 +29,7 @@ const configurationValid = {
     watchall: false,
     watchevents: true,
     cron: '0 * * * *',
+    watchatstart: true,
 };
 
 jest.mock('request-promise-native');

--- a/docs/configuration/watchers/README.md
+++ b/docs/configuration/watchers/README.md
@@ -19,6 +19,7 @@ The ```docker``` watcher lets you configure the Docker hosts you want to watch.
 | `WUD_WATCHER_{watcher_name}_WATCHBYDEFAULT`               | :white_circle: | If WUD must monitor all containers by default                   | `true`, `false`                                | `true`                                                          |
 | `WUD_WATCHER_{watcher_name}_WATCHALL`                     | :white_circle: | If WUD must monitor all containers instead of just running ones | `true`, `false`                                | `false`                                                         |
 | `WUD_WATCHER_{watcher_name}_WATCHEVENTS`                  | :white_circle: | If WUD must monitor docker events                               | `true`, `false`                                | `true`                                                          |
+| `WUD_WATCHER_{watcher_name}_WATCHATSTART`                 | :white_circle: | If WUD must check for image updates during startup              | `true`, `false`                                | `true`                                                          |
 | ~~`WUD_WATCHER_{watcher_name}_WATCHDIGEST`~~ (deprecated) | :white_circle: | If WUD must monitor container digests                           |                                                | `false` for semver image tags, `true` for non semver image tags |
 
 ?> If no watcher is configured, a default one named `local` will be automatically created (reading the Docker socket).


### PR DESCRIPTION
Adds the possiblity to configure the start behaviour of wud, i.e. wud watches for image updates at startup only if the newly added conditional watchatstart is true (which it is by default to avoid breaking changes for existing users. Fixes https://github.com/fmartinou/whats-up-docker/issues/448

Also adds the documentation for the new watchatstart conditional.

I hope this small addition will be of interest and helpful for others. If there is anything I missed or implemented in the wrong way, please give me a hint.